### PR TITLE
ci(compile.yml): Update dependencies

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,21 +11,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 
       - name: Setup Typst
-        uses: yusancky/setup-typst@v2.0.1
-        id: setup-typst
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'latest'
+          typst-version: 'latest'
 
       - run: typst compile cv.typ --font-path ./src/fonts
       - run: typst compile letter.typ --font-path ./src/fonts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: output
           path: ./*.pdf


### PR DESCRIPTION
> [!WARNING] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://gist.github.com/yusancky/b676f56d40d6346dfc67ed477ca2ea1a) for more information.

> [!WARNING]
> `actions/upload-artifact@v3` was deprecated on November 30, 2024. [Learn More](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)